### PR TITLE
build: Downgrade scikit-learn 1.3.0 -> 1.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ numpy >=1.16
 requests >=2.24
 scipy >=1.4
 setuptools >=49.6
-scikit-learn >=0.23
+scikit-learn >=0.23,<=1.2.2
 tqdm >=4.48
 tensorflow >=2.3
 pandas >=1.1


### PR DESCRIPTION
Recent scikit-learn 1.3.0 update breaks tests.